### PR TITLE
fix(renovate): renovate handle unbound version scheme

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":disableRateLimiting"],
+  "extends": [
+    ":disableRateLimiting",
+    "config:best-practices",
+    "github>isejalabs/homelab//.github/renovate/version-scheme"
+  ],
   "assignees": ["sebiklamar"],
   "ignorePaths": ["_attic/**"],
   "terragrunt": {

--- a/.github/renovate/version-scheme.json
+++ b/.github/renovate/version-scheme.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "configure version scheme for various docker images needing loose versioning",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "docker.io/plexinc/pms-docker",
+        "docker.io/madnuttah/unbound"
+      ],
+      "versioning": "loose"
+    },
+    {
+      "description": "configure version scheme for minio images",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "docker.io/minio/minio",
+        "docker.io/minio/mc"
+      ],
+      "versioning": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T\\d{2}-\\d{2}-\\d{2}Z$"
+    }
+  ]
+}


### PR DESCRIPTION
- adopted from https://github.com/ppat/homelab-ops-kubernetes-apps/blob/78cdd3e9c9405b0f5119e2cd96fe8635b61c6648/.github/renovate/version-scheme.json#L24-L34
- sticking to docker.io container prefix in image tag
- also move `renovate.json` to sub-folder to have root clean

closes #394