### PR TITLE
fix(adguard,whoami): proper upstream handling

### DIFF
--- a/k8s/apps/diag/whoami/base/http-route.yaml
+++ b/k8s/apps/diag/whoami/base/http-route.yaml
@@ -20,6 +20,6 @@ spec:
       backendRefs:
         - group: ""
           kind: Service
-          name: whoami
+          name: whoami-gw
           port: 80
           weight: 1

--- a/k8s/apps/diag/whoami/base/kustomization.yaml
+++ b/k8s/apps/diag/whoami/base/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - ns.yaml
   - svc.yaml
+  - svc-gw.yaml
   - deployment.yaml
   - http-route.yaml

--- a/k8s/apps/diag/whoami/base/svc-gw.yaml
+++ b/k8s/apps/diag/whoami/base/svc-gw.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-gw
+  namespace: whoami
+spec:
+  type: ClusterIP
+  selector:
+    app: whoami
+  ports:
+    - name: web
+      port: 80
+      targetPort: http

--- a/k8s/apps/dns/adguard/base/http-route.yaml
+++ b/k8s/apps/dns/adguard/base/http-route.yaml
@@ -19,6 +19,6 @@ spec:
       backendRefs:
         - group: ""
           kind: Service
-          name: adguard
+          name: adguard-gw
           port: 3000
           weight: 1

--- a/k8s/apps/dns/adguard/base/kustomization.yaml
+++ b/k8s/apps/dns/adguard/base/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
 resources:
   - ns.yaml
   - svc.yaml
+  - svc-gw.yaml
   - secret-users.yaml
   - deployment.yaml
   - http-route.yaml

--- a/k8s/apps/dns/adguard/base/svc-gw.yaml
+++ b/k8s/apps/dns/adguard/base/svc-gw.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: adguard-gw
+  namespace: dns
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+  selector:
+    app: adguard

--- a/k8s/apps/dns/adguard/base/svc.yaml
+++ b/k8s/apps/dns/adguard/base/svc.yaml
@@ -9,9 +9,6 @@ spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
   ports:
-    - name: http
-      protocol: TCP
-      port: 3000
     - name: dns-tcp
       port: 53
       protocol: TCP


### PR DESCRIPTION
split-up HTTP service from other services served by LB, cf. https://github.com/cilium/cilium/issues/41482#issuecomment-3332525530

this fixes the bug where the HTTP route reported "no upstream available" (cf. #418)

fixes #418