### PR TITLE
feat: automerge by renovate and mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,17 @@
+queue_rules: []
+pull_request_rules:
+  - name: Automatic Merge for HEAD environment
+    conditions:
+      - label=pr-type:renovate    # renovate PRs only, i.e. exclude manual PRs
+      - label=env:head            # only for HEAD environment, i.e. like "latest" updates
+    actions:
+      merge:
+        method: squash            # Choose merge, squash or rebase
+  - name: Auto-Merge minor not flagged for automerge:off
+    conditions:
+      - label=pr-type:renovate    # renovate PRs only, i.e. exclude manual PRs
+      - label=updateType:minor    # PRs for minor updates 
+      - label!=automerge:off      # ... unless excluded from automerging
+    actions:
+      merge:
+        method: squash            # Choose  merge, squash or rebase

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,8 @@
   extends: [
     ":disableRateLimiting",
     "config:best-practices",
+    "github>isejalabs/homelab//.github/renovate/automerge-enable.json5",
+    "github>isejalabs/homelab//.github/renovate/automerge-disable.json5",
     "github>isejalabs/homelab//.github/renovate/labels.json5",
     "github>isejalabs/homelab//.github/renovate/organize-semantic-scope.json5",
     "github>isejalabs/homelab//.github/renovate/pin-versions.json5",
@@ -50,4 +52,7 @@
     },
   ],
   commitMessageAction: "{{{updateType}}}",
+  "labels": [
+    "pr-type:renovate"
+  ],
 }

--- a/.github/renovate/automerge-disable.json5
+++ b/.github/renovate/automerge-disable.json5
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "disable automerge for specific packages",
+      "matchPackageNames": [
+        "cilium",
+        "kubernetes-sigs/gateway-api",
+        "kubernetes/kubernetes",
+        "sidero/talos"
+      ],
+      "automerge": false,
+      "addLabels": [
+        "automerge:off"
+      ],
+    },
+    {
+      "description": "disable automerge for specific file paths",
+      "matchFileNames": [
+        ".github/**",
+        "terragrunt/**",
+        "tofu/**",
+      ],
+      "automerge": false,
+      "addLabels": [
+        "automerge:off"
+      ],
+    },
+  ],
+}

--- a/.github/renovate/automerge-enable.json5
+++ b/.github/renovate/automerge-enable.json5
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      matchUpdateTypes: [
+        "digest",
+        "pinDigest",
+        "patch",
+      ],
+      "automerge": true,
+    },
+    {
+      matchDepTypes: [
+        'devDependencies',
+      ],
+      "automerge": true,
+    },
+  ],
+  automergeType: "branch",
+}

--- a/docs/update handling.md
+++ b/docs/update handling.md
@@ -1,0 +1,116 @@
+# Update Handling and Automerging of PRs
+
+## Overview
+
+### Toolchain
+
+- **renovate**: A tool for automating dependency updates, which creates PRs for package updates. It not only creates PRs but also labels them and also automerges them based on the type of update and whether they should be automerged or not.
+- **labeler**: A tool for automatically labeling PRs based on their content and the rules defined in the configuration. It is used to label PRs with the environment (e.g., `env:PROD`, `env:QA`) and the area a PR is affecting (e.g., `area:terraform`, `area:k8s`), which are then used by mergify to determine whether a PR should be automerged or not.
+- **mergify**: A tool for automating the merging of PRs based on specific conditions. It is configured to automatically merge PRs created by renovate for certain types of updates and configuration changes, while excluding others based on labels.
+- **argo-cd**: A tool for automating the deployment of applications to Kubernetes, following the **GitOps** approach. It is used to deploy changes to the k8s cluster based on what is defined in `git`, instead of a user applying the changes manually by, e.g., `kubectl apply`.
+
+## Configuration changes
+
+### K8S and argo-cd
+
+Configuration changes for k8s packages are handled differently, based on the environment. For production and test environments, the manifest are applied by argo-cd. For development environments, the manifest are applied manually by a user. For other environments, also applicable for testing, it depends on the specific test scenario investigated,
+
+#### argo-cd
+
+- HEAD
+- PROD
+- QA
+- REBUILD
+
+#### manually
+
+- DEV
+- SRC
+
+#### depends on test scenario
+
+Depending on the test scenario, configuration changes for k8s packages might be applied manually by the user or by argo-cd. This is the case for environments used for testing, which are not production or test environments. Examples for manual handling might be, e.g., testing/investigating a specific application or its specific version, without requiring a full deployment. Examples for argo-cd handling might be testing a full deployment, besides the REBUILD environment, or investigating argo-cd features or issues.
+
+- DBG
+- POC
+
+### terraform/terragrunt
+
+Configuration changes for infrastructure packages managed by terraform/terragrunt are handled manually, as they require manual review of the changes/plan. There's no CI (continuous integration) for the core infrastrucure. Hence,  PRs created by renovate for these packages are labeled with `automerge:off` to exclude them from automerging by renovate and mergify.
+
+## Detecting package updates
+
+### renovate
+
+Package updates are handled by renovate, which creates PRs for updates to packages. These PRs are labeled with `pr-type:renovate` and specific labels indicating the type of update (e.g., `updateType:digest`, `updateType:patch`, `updateType:minor`). Renovate is also configured to automatically merge PRs for certain types of updates (e.g., `digest`, `pinDigest`, `patch`), while excluding critical/terragrunt-managed packages from automerging by labeling them with `automerge:off`.
+
+Renovate is configured to create separate PRs for different environments (e.g. PROD, QA) and types of updates (`major`, `minor`, `patch`, incl. `separateMinorPatch=true`), which allows for more granular control over which updates are automerged and which require manual review or explicit testing before they are promoted.
+
+## Merging PRs for package updates
+
+
+### Automatic merging rules
+
+Renovate is configured to automatically certain types of updates (e.g., `digest`, `pinDigest`, `patch`), while excluding critical/terragrunt-managed packages from automerging by labeling them with `automerge:off`. Mergify is configured to automatically merge PRs for the `HEAD` environment as well as updates of type `minor`, unless they are excluded from auto-merging labeled `automerge:off`.
+
+Generally, automerging is configured only for PRs created by renovate (labeled `pr-type:renovate`, thus excluding PRs created in other ways, e.g. by a user) and based on specific conditions. The conditions for automerging are as follows:
+
+- **renovate**: Automerge small updates , except for critical/terragrunt-managed packages (labeled `automerge:off`, cf. below). The types of updates are:
+	- `digest` (labeled `updateType:digest`)
+	- `pinDigest` (labeled `updateType:pinDigest`), and
+	- `patch` (labeled `updateType:patch`)
+- **mergify**: Mergify is merging PRs on the following criterias:
+  - `env:head`: Automerge PRs for `HEAD` environment (labeled `env:head`), regardless of the area (k8s, terraform/terragrunt, etc.) and whether they are exluded from automerging (labeled `automerge:off`). They need to be created by renovate (labelled `pr-type:renovate`), nevertheless.
+  - `updateType:minor`: Automerge PRs for updates of type `minor` (labeled `updateType:minor`), unless they are excluded from automerging (labeled `automerge:off`), if they change files in the `k8s/` folder.
+
+### PR creation, checking and notification
+
+#### Reducing PR noise
+
+Automerging is configured as `automergeType=branch` in renovate, which means that renovate will automatically merge the branch created instead of creating a PR. However, this is currently not working as expected, and PRs are still being created instead of branches being merged directly. This issue needs to be investigated further to determine the cause and find a solution.
+
+### Handling special apps and use cases
+
+Some packages have a non-standard update strategy, e.g. by allowing only updates of type `patch` or by pinning them to a specific version or by not allowing updates at all. There's also an exception for the `HEAD` environment.
+
+#### HEAD environment
+
+Updates applicable to the `HEAD` environment are automerged regardless of the type of update, as they are only applied to the `HEAD` environment and thus do not pose a risk to the stability of the production or other test environments. This is done to test new application versions and updates as soon as they are available in a dedicated test environment (like tracking `latest` or `edge` version), which allows for early detection of potential issues and ensures that the latest versions are being tested.
+
+#### Non-standard update strategy
+
+Package | Update strategy | Description
+------- | --------------- | ---
+`cilium` | Pin previous minor | Pinned to the "oldstable" version, i.e. previous minor version (for `cilium` being `X.Y-1`, e.g. 1.18.x instead of 1.19.x). Only `patch` updates are allowed. This is done for extra stability, as `cilium` is a critical component of the cluster and updates of type `minor` might introduce new features which could cause issues (and are not needed for proper functioning).
+`kubernetes-sigs/gateway-api` | Pin minor | Pinned to a specific minor version in accordance with other application compatibility constraints (`cilium`). Only `patch` updates are allowed.
+`kubernetes/kubernetes` | Pin minor | Pinned to a specific minor version in accordance with other application compatibility constraints (e.g. `checkmk`). Only `patch` updates are allowed.
+`mongo` | Pin Minor | Pinned to a specific minor version (`8.0`) in accordance with other application compatibility constraints (unific-application-controller). Only `patch` updates are allowed, as updates of type `minor` introduce new features which might cause issues (and are not needed for proper functioning).
+
+#### Excluded packages from auto-merging
+
+Some packages are excluded from automerging due to their criticality or because they are managed by terragrunt, which requires manual handling. These packages are labeled with `automerge:off` in renovate configuration and excluded from automerging in mergify configuration. The exceptional packages are
+
+- `cilium`,
+- `kubernetes-sigs/gateway-api`,
+- `kubernetes/kubernetes`,
+- `sidero/talos`
+
+#### Excluded file paths from auto-merging
+
+Some file paths are excluded from automerging due to the need for manual handling and review of changes, e.g. for testing or implementation purposes. These file paths are labeled with `automerge:off` in renovate configuration and excluded from automerging in mergify configuration. The exceptional file paths are:
+
+- `.github/**`
+- `terragrunt/**`
+- `tofu/**`
+
+## Pending
+
+Some asprects still need to be investigated and tested further to ensure that the automerging of updates is working as expected and that the configuration is correctly set up to handle different types of updates and environments. These include:
+
+- [ ] `automergeType=branch` not working (PRs get created nevertheless)
+- [ ] investigate necessity for disabling updates for `mongo` and maybe `unifi-controller` (enabled currently)
+- [ ] pin `cilium`, `gateway-api` and `kubernetes` to specific minor versions to reduce PR noise; PRs only should get created when necessary without the need to ignore them "until a certain solution is released" or "depending on further testing"; PRs should be only ignored for a while if they 
+  - need to be handled manually for testing and/or implementation (e.g. manual handling of terraform/terragrunt), or
+  - are waiting for promotion to production, e.g. due to the need for testing in a specific environment, or 
+  - are expected to cause issues, e.g. due to new features being introduced in a major (or minor) update; otherwise, PRs should be created and automerged as soon as they are available, even if they are for minor updates, to ensure that the latest versions are being tested and used.
+- [ ] PRs for `unbound` not updated in recent tests in `renovate-test` repo


### PR DESCRIPTION
## Motivation

Handle non-critical updates automatically, for reducing manual effort and to have latest and stable versions.
Also allow tracking of `latest` (rather named versions) in HEAD environment.

closes #110

## Approach

Renovate is configured to automatically certain types of updates (e.g., `digest`, `pinDigest`, `patch`), while excluding critical/terragrunt-managed packages from automerging by labeling them with `automerge:off`. Mergify is configured to automatically merge PRs for the `HEAD` environment as well as updates of type `minor`, unless they are excluded from auto-merging labeled `automerge:off`.

- configure renovate to automerge certain updates
- introduce new tool mergify in the toolchain
- documentation in `docs/update handling.md`
- exclude updates in terraform/terragrunt area, as these need to be applied manually, and one wants to keep package version in git close to live version

## Pending

Some asprects still need to be investigated and tested further to ensure that the automerging of updates is working as expected and that the configuration is correctly set up to handle different types of updates and environments. These include:

- [ ] `automergeType=branch` not working (PRs get created nevertheless)
- [ ] investigate necessity for disabling updates for `mongo` and maybe `unifi-controller` (enabled currently)
- [ ] pin cilium, gateway-api and kubernetes to specific minor versions to reduce PR noise; PRs only should get created when necessary without the need to ignore them "until a certain solution is released" or "depending on further testing"; PRs should be only ignored for a while if they 
  - need to be handled manually for testing and/or implementation (e.g. manual handling of terraform/terragrunt), or
  - are waiting for promotion to production, e.g. due to the need for testing in a specific environment, or 
  - are expected to cause issues, e.g. due to new features being introduced in a major (or minor) update; otherwise, PRs should be created and automerged as soon as they are available, even if they are for minor updates, to ensure that the latest versions are being tested and used.
- [ ] PRs for `unbound` not updated in recent tests in `renovate-test` repo