### PR TITLE
fix: always have namespace in kustomize

### DIFF
--- a/k8s/apps/diag/shell/base/kustomization.yaml
+++ b/k8s/apps/diag/shell/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: diag
+
 resources:
   - ns.yaml
   - deployment.yaml

--- a/k8s/apps/diag/whoami/base/kustomization.yaml
+++ b/k8s/apps/diag/whoami/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: whoami
+
 resources:
   - ns.yaml
   - svc.yaml

--- a/k8s/apps/monitoring/hubble/base/kustomization.yaml
+++ b/k8s/apps/monitoring/hubble/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kube-system
+
 resources:
   - http-route.yaml

--- a/k8s/apps/monitoring/metrics-server/base/kustomization.yaml
+++ b/k8s/apps/monitoring/metrics-server/base/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# resources:
-#   - https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+namespace: kube-system
 
 helmCharts:
   - name: metrics-server
@@ -10,3 +9,4 @@ helmCharts:
     version: 3.13.0
     releaseName: metrics-server
     namespace: kube-system
+

--- a/k8s/apps/ras/openssh/base/kustomization.yaml
+++ b/k8s/apps/ras/openssh/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: ssh
+
 resources:
   - ns.yaml
   - svc.yaml
@@ -10,3 +12,4 @@ configMapGenerator:
   - name: ssh-install-packages-script
     files:
       - assets/custom-cont-init.d/install-packages.sh
+

--- a/k8s/core/controller/sealed-secrets/base/kustomization.yaml
+++ b/k8s/core/controller/sealed-secrets/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: sealed-secrets
+
 helmCharts:
   - name: sealed-secrets
     repo: oci://registry-1.docker.io/bitnamicharts

--- a/k8s/core/network/cilium/base/kustomization.yaml
+++ b/k8s/core/network/cilium/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kube-system
+
 resources:
   - bgp-peer-config.yaml
   - bgp-advertisement.yaml

--- a/k8s/core/network/gateway/base/kustomization.yaml
+++ b/k8s/core/network/gateway/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: gateway
+
 resources:
   - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
   - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.4.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml

--- a/k8s/infra/controller/kubelet-serving-cert-approver/base/kustomization.yaml
+++ b/k8s/infra/controller/kubelet-serving-cert-approver/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kube-system
+
 resources:
   - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml

--- a/k8s/infra/network/gateway-redirect/base/kustomization.yaml
+++ b/k8s/infra/network/gateway-redirect/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: gateway
+
 # have a separate kustomization without domain/hostname rewrites
 # hence no components or transformers here
 

--- a/k8s/infra/storage/proxmox-csi/base/kustomization.yaml
+++ b/k8s/infra/storage/proxmox-csi/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: csi-proxmox
+
 helmCharts:
   - name: proxmox-csi-plugin
     repo: oci://ghcr.io/sergelogvinov/charts


### PR DESCRIPTION
## Motivation

#603 had some flaws by depending on a namespace definition in kustomize which wasn't there always, e.g., it was missing for https://github.com/isejalabs/homelab/blob/7b13cf13dabdbaa7b288b32b5b4ac064f44db1bb/k8s/infra/network/gateway-redirect/base/kustomization.yaml#L1-L8

## Content

- add `namespace:` stanza to each and very `base/kustomize.yaml`
- adds to #565 