### PR TITLE
feat(scripts): upgrade-k8s detects cluster automatically

### DIFF
--- a/scripts/upgrade-k8s.sh
+++ b/scripts/upgrade-k8s.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
-# Usage: sh upgrade-k8s.sh <controlplane node> or sh upgrade-k8s.sh <controlplane node> --dry-run (for a dry run)
-talosctl $2 --nodes $1 upgrade-k8s --to 1.34.5 # renovate: github-releases=kubernetes/kubernetes
+
+TALCONFIG=$(find . -iname talos-config.yaml)
+
+# Usage: upgrade-k8s.sh [--dry-run]
+talosctl upgrade-k8s $1 --talosconfig ${TALCONFIG} --nodes $( yq -r '.contexts.*.endpoints.[0]' ${TALCONFIG}) --to 1.34.5 # renovate: github-releases=kubernetes/kubernetes


### PR DESCRIPTION
This PR makes the `upgrade-k8s` script more flexible and user-friendly by auto-detecting the targeted cluster.
For this to work the working directory needs to be chosen properly. It needs to be the terragrunt module dir.

usage | command | working directory
--- | --- | ---
before | `upgrade-k8s <node> [--dry-run]` | any
new | `upgrade-k8s [--dry-run]` | `terragrunt/.../dev/vehagn-k8s`