### PR TITLE
feat: actualbudget

### DIFF
--- a/k8s/apps/misc/actualbudget/base/helm/helmChart.yaml
+++ b/k8s/apps/misc/actualbudget/base/helm/helmChart.yaml
@@ -3,6 +3,7 @@ kind: HelmChartInflationGenerator
 metadata:
   name: &name actualbudget
 name: *name
+# only default namespace is supported by this helm chart, so we do not specify it
 # namespace: *name
 repo: https://community-charts.github.io/helm-charts
 releaseName: *name
@@ -11,6 +12,9 @@ version: 1.8.7    # renovate: helm=actualbudget registry=https://community-chart
 # valuesFile: values.yaml
 ## only inline values are inherited in overlays
 valuesInline:
+  image:
+    tag: "26.4.0" # renovate: docker=ghcr.io/actualbudget/actual-server versioning=loose
+
   persistence:
     enabled: true
     size: 1Gi

--- a/k8s/apps/misc/actualbudget/base/helm/helmChart.yaml
+++ b/k8s/apps/misc/actualbudget/base/helm/helmChart.yaml
@@ -1,0 +1,19 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: &name actualbudget
+name: *name
+# namespace: *name
+repo: https://community-charts.github.io/helm-charts
+releaseName: *name
+version: 1.8.7    # renovate: helm=actualbudget registry=https://community-charts.github.io/helm-charts
+## do not use valuesFile as it's not inherited in overlays
+# valuesFile: values.yaml
+## only inline values are inherited in overlays
+valuesInline:
+  persistence:
+    enabled: true
+    size: 1Gi
+
+  strategy:
+    type: Recreate

--- a/k8s/apps/misc/actualbudget/base/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/base/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - helmChart.yaml

--- a/k8s/apps/misc/actualbudget/base/http-route.yaml
+++ b/k8s/apps/misc/actualbudget/base/http-route.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: actualbudget
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal
+      namespace: gateway
+  hostnames:
+    - budget.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: actualbudget
+          port: 5006
+          weight: 1

--- a/k8s/apps/misc/actualbudget/base/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# only default namespace is supported by this helm chart, so we do not specify it
 namespace: default
 
 resources:

--- a/k8s/apps/misc/actualbudget/base/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+  # - ns.yaml
+  - http-route.yaml

--- a/k8s/apps/misc/actualbudget/base/ns.yaml
+++ b/k8s/apps/misc/actualbudget/base/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _

--- a/k8s/apps/misc/actualbudget/envs/dbg/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/dbg/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/dbg/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/dbg/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/dbg
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm

--- a/k8s/apps/misc/actualbudget/envs/dev/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/dev/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/dev/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/dev
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm

--- a/k8s/apps/misc/actualbudget/envs/head/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/head/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/head/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/head/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/head
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm

--- a/k8s/apps/misc/actualbudget/envs/poc/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/poc/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/poc/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/poc/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/poc
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm

--- a/k8s/apps/misc/actualbudget/envs/prod/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/prod/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/prod/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/prod/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/prod
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm

--- a/k8s/apps/misc/actualbudget/envs/qa/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/qa/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/qa/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/qa/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/qa
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm

--- a/k8s/apps/misc/actualbudget/envs/rebuild/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/rebuild/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/rebuild/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/rebuild/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/rebuild
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm

--- a/k8s/apps/misc/actualbudget/envs/src/helm/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/src/helm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/helm

--- a/k8s/apps/misc/actualbudget/envs/src/kustomization.yaml
+++ b/k8s/apps/misc/actualbudget/envs/src/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../../_components/src
+
+resources:
+  - ../../base
+
+generators:
+  - ./helm


### PR DESCRIPTION
Implement [Actual Budget](https://redirect.github.com/actualbudget/actual)

## Caveats

- Deployed to `default` namespace instead of to a dedicated one due to limitations of `kustomize` (using `helm template`) which does not enrich the resources with a namespace (due to them not part of the `template`d resources)
- Persistent volume not named