### PR TITLE
refactor: streamline ns manifests

### DIFF
--- a/_attic/k8s/apps/diag/openssh/base/ns.yaml
+++ b/_attic/k8s/apps/diag/openssh/base/ns.yaml
@@ -1,7 +1,10 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: diag
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   # labels:
   #   pod-security.kubernetes.io/enforce: privileged
   #   pod-security.kubernetes.io/enforce-version: latest

--- a/_attic/k8s/apps/diag/shell/base/ns.yaml
+++ b/_attic/k8s/apps/diag/shell/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: diag
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/_attic/k8s/apps/ras/openssh/base/ns.yaml
+++ b/_attic/k8s/apps/ras/openssh/base/ns.yaml
@@ -1,7 +1,10 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ssh
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   # labels:
   #   pod-security.kubernetes.io/enforce: privileged
   #   pod-security.kubernetes.io/enforce-version: latest

--- a/k8s/apps/diag/whoami/base/ns.yaml
+++ b/k8s/apps/diag/whoami/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: whoami
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/dns/adguard/base/ns.yaml
+++ b/k8s/apps/dns/adguard/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: dns
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/dns/unbound/base/ns.yaml
+++ b/k8s/apps/dns/unbound/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: unbound
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/finances/actualbudget/base/ns.yaml
+++ b/k8s/apps/finances/actualbudget/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/apps/monitoring/checkmk-agent/base/ns.yaml
+++ b/k8s/apps/monitoring/checkmk-agent/base/ns.yaml
@@ -1,7 +1,10 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: checkmk-kube-agent
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/enforce: privileged

--- a/k8s/apps/network/unifi-controller/base/ns.yaml
+++ b/k8s/apps/network/unifi-controller/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: unifi
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/infra/controller/cert-manager-core/base/ns.yaml
+++ b/k8s/infra/controller/cert-manager-core/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cert-manager
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/infra/network/gateway/base/ns.yaml
+++ b/k8s/infra/network/gateway/base/ns.yaml
@@ -1,4 +1,7 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: gateway
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/k8s/infra/storage/longhorn-core/base/ns.yaml
+++ b/k8s/infra/storage/longhorn-core/base/ns.yaml
@@ -1,7 +1,10 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: longhorn-system
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Motivation

Closes #1001 

## Content

- change metadata.name to `_` as the name is set from kustomize
- add `kustomize.toolkit.fluxcd.io/prune: disabled` annotation

new setup:

```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  name: _
  annotations:
    kustomize.toolkit.fluxcd.io/prune: disabled
```