### PR TITLE
feat(helmfile): helmfile version from ocirelease

### DIFF
--- a/k8s/bootstrap/helmfile/default.yaml
+++ b/k8s/bootstrap/helmfile/default.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/helmfile
+templates:
+  default:
+    chart: '{{ (fromYaml (tpl (readFile "./templates/release.yaml.gotmpl") .)).chart }}'
+    version: '{{ (fromYaml (tpl (readFile "./templates/release.yaml.gotmpl") .)).version }}'

--- a/k8s/bootstrap/helmfile/helmfile.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/helmfile.yaml.gotmpl
@@ -13,6 +13,11 @@ environments:
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/helmfile
 
+bases:
+  - default.yaml
+
+defaultInherit: default
+
 helmDefaults:
   cleanupOnFail: true
   kubeContext: {{ printf "admin@%s-homelab" .Environment.Name }}
@@ -22,15 +27,11 @@ helmDefaults:
 releases:
   - name: flux-operator
     namespace: flux-system
-    chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
-    version: 0.58.1
     values:
       - ../../infra/flux-system/flux-operator/base/values.yaml
 
   - name: flux-instance
     namespace: flux-system
-    chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
-    version: 0.58.1
     wait: false
     values:
       - ../../infra/flux-system/flux-instance/base/values.yaml

--- a/k8s/bootstrap/helmfile/templates/release.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/templates/release.yaml.gotmpl
@@ -1,3 +1,20 @@
-{{- $oci := fromYaml (readFile (printf "../../infra/%s/%s/base/ocirepository.yaml" .Release.Namespace .Release.Name)) -}}
-chart: {{ $oci.spec.url }}
-version: {{ $oci.spec.ref.tag }}
+# 0. Some constants
+{{- $baseFile := printf "../../infra/%s/%s/base/ocirepository.yaml" .Release.Namespace .Release.Name -}}
+{{- $envFile := printf "../../infra/%s/%s/envs/%s/ocirepository.yaml" .Release.Namespace .Release.Name .Environment.Name -}}
+
+# 0. Initialize the environment variable
+{{- $env := dict -}}
+
+# 1. Source files and parse the base/env YAML string into a map
+{{- $base := readFile $baseFile | fromYaml -}}
+# envfile is optional and might not exist, hence needs to check if it exists before reading it
+{{- if isFile $envFile -}}
+{{- $env = readFile $envFile | fromYaml -}}
+{{- end -}}
+
+# 2. Merge '$env' and '$base' with $env taking precedence over $base
+{{- $merged := merge $env $base -}}
+
+# 4. Define final YAML
+chart: {{ $merged.spec.url }}
+version: {{ $merged.spec.ref.tag }}

--- a/k8s/bootstrap/helmfile/templates/release.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/templates/release.yaml.gotmpl
@@ -1,0 +1,3 @@
+{{- $oci := fromYaml (readFile (printf "../../infra/%s/%s/base/ocirepository.yaml" .Release.Namespace .Release.Name)) -}}
+chart: {{ $oci.spec.url }}
+version: {{ $oci.spec.ref.tag }}


### PR DESCRIPTION
Read the helm chart URL and version from the `OCIRepository` definition, thus eliminiating the duplicate (and potential inconsistent) definition in the helmfile. Also allows environmental differences.

## Motivation

closes #996 

## Content

Establish f. helmfile template files:

- k8s/bootstrap/helmfile/default.yaml
- k8s/bootstrap/helmfile/templates/release.yaml.gotmpl

Assumes the `OCIRepository` definition to be stated in:

```yaml
{{- $baseFile := infra/<namespace>/<releaseName>/base/ocirepository.yaml" -}}
{{- $envFile := infra/<namespace>/<releaseName>/envs/<env>/ocirepository.yaml" -}}
```

## Pending

- [ ] Use uniform filename (`ocirepository.yaml`) for `OCIRepository` manifests.  E.g., cilium is using `helm-version.yaml` in some of its environments

```sh
$ grep OCIRepository k8s/**/envs/*/*yaml
k8s/infra/kube-system/cilium-core/envs/head/helm-version.yaml:kind: OCIRepository
k8s/infra/kube-system/cilium-core/envs/poc/helm-version.yaml:kind: OCIRepository
k8s/infra/kube-system/cilium-core/envs/prod/helm-version.yaml:kind: OCIRepository
```