### PR TITLE
feat(helmfile): read helm chart values from optional env files

### DIFF
--- a/k8s/bootstrap/helmfile/default.yaml
+++ b/k8s/bootstrap/helmfile/default.yaml
@@ -4,5 +4,8 @@ templates:
   default:
     chart: '{{ (fromYaml (tpl (readFile "./templates/release.yaml.gotmpl") .)).chart }}'
     version: '{{ (fromYaml (tpl (readFile "./templates/release.yaml.gotmpl") .)).version }}'
+    # Ignore missing files, as they are optional and might not exist
+    missingFileHandler: Debug
     values:
-      - ./templates/values.yaml.gotmpl
+    - ../../infra/{{ .Release.Namespace }}/{{ .Release.Name }}/base/values.yaml
+    - ../../infra/{{ .Release.Namespace }}/{{ .Release.Name }}/envs/{{ .Environment.Name }}/env-values.yaml

--- a/k8s/bootstrap/helmfile/default.yaml
+++ b/k8s/bootstrap/helmfile/default.yaml
@@ -4,3 +4,5 @@ templates:
   default:
     chart: '{{ (fromYaml (tpl (readFile "./templates/release.yaml.gotmpl") .)).chart }}'
     version: '{{ (fromYaml (tpl (readFile "./templates/release.yaml.gotmpl") .)).version }}'
+    values:
+      - ./templates/values.yaml.gotmpl

--- a/k8s/bootstrap/helmfile/helmfile.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/helmfile.yaml.gotmpl
@@ -27,14 +27,9 @@ helmDefaults:
 releases:
   - name: flux-operator
     namespace: flux-system
-    values:
-      - ../../infra/flux-system/flux-operator/base/values.yaml
 
   - name: flux-instance
     namespace: flux-system
     wait: false
-    values:
-      - ../../infra/flux-system/flux-instance/base/values.yaml
-      - ../../infra/flux-system/flux-instance/envs/{{ .Environment.Name }}/env-values.yaml 
     needs:
       - flux-system/flux-operator

--- a/k8s/bootstrap/helmfile/templates/values.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/templates/values.yaml.gotmpl
@@ -1,1 +1,0 @@
-{{ (fromYaml (readFile (printf "../../../infra/%s/%s/base/helmrelease.yaml" .Release.Namespace .Release.Name)) | default "{}" ).spec.values | toYaml }}

--- a/k8s/bootstrap/helmfile/templates/values.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/templates/values.yaml.gotmpl
@@ -1,0 +1,1 @@
+{{ (fromYaml (readFile (printf "../../../infra/%s/%s/base/helmrelease.yaml" .Release.Namespace .Release.Name)) | default "{}" ).spec.values | toYaml }}


### PR DESCRIPTION
## Motivation

Closes #1034 

## Content

Read helm chart values from helm chart base and optional environment (<app>/envs/<env>/env-values.yaml).  This also works if the values.yaml file does not exist

- adapted from release template documentation example from https://helmfile.readthedocs.io/en/latest/writing-helmfile/#release-template-conventional-directory-structure
- leverages `missingFileHandler: Debug` to ignore missing values files
- (as usually) env. values will extend and override base values

## Pending

- [ ] might not work for cilium where the env. values are defined exclusively, i.e. the `base/values.yaml` need to get ignored