### PR TITLE
refactor(longhorn): prefix job name with time scope

### DIFF
--- a/k8s/infra/longhorn-system/longhorn/base/job-backup-default.yaml
+++ b/k8s/infra/longhorn-system/longhorn/base/job-backup-default.yaml
@@ -2,7 +2,7 @@
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
-  name: default-backup-daily
+  name: daily-backup
   namespace: longhorn-system
 spec:
   task: backup
@@ -17,7 +17,7 @@ spec:
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
-  name: default-backup-weekly
+  name: weekly-backup
   namespace: longhorn-system
 spec:
   task: backup
@@ -32,7 +32,7 @@ spec:
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
-  name: default-backup-monthly
+  name: monthly-backup
   namespace: longhorn-system
 spec:
   task: backup

--- a/k8s/infra/longhorn-system/longhorn/base/job-fs-trim-default.yaml
+++ b/k8s/infra/longhorn-system/longhorn/base/job-fs-trim-default.yaml
@@ -2,7 +2,7 @@
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
-  name: default-trim-weekly
+  name: weekly-trim
   namespace: longhorn-system
 spec:
   task: filesystem-trim

--- a/k8s/infra/longhorn-system/longhorn/base/job-snapshot.yaml
+++ b/k8s/infra/longhorn-system/longhorn/base/job-snapshot.yaml
@@ -2,7 +2,7 @@
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
-  name: default-snapshot-hourly
+  name: hourly-snapshot
   namespace: longhorn-system
 spec:
   task: snapshot


### PR DESCRIPTION
having time scope {hourly,daily,weekly} in front of job name eases identification when listing jobs/backups/snapshots in GUI or console