### PR TITLE
refactor(helmfile): kubeContext into separate helmDefaults

### DIFF
--- a/k8s/bootstrap/helmfile/base/helmDefaults.yaml
+++ b/k8s/bootstrap/helmfile/base/helmDefaults.yaml
@@ -1,5 +1,4 @@
 helmDefaults:
   cleanupOnFail: true
-  kubeContext: {{ printf "admin@%s-homelab" .Environment.Name }}
   wait: true
   waitForJobs: true

--- a/k8s/bootstrap/helmfile/base/kubeContext.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/base/kubeContext.yaml.gotmpl
@@ -1,0 +1,2 @@
+helmDefaults:
+  kubeContext: {{ printf "admin@%s-homelab" .Environment.Name }}

--- a/k8s/bootstrap/helmfile/helmfile.yaml
+++ b/k8s/bootstrap/helmfile/helmfile.yaml
@@ -4,7 +4,8 @@
 bases:
   - base/release-templates.yaml
   - base/environments.yaml
-  - base/helmdefaults.yaml.gotmpl
+  - base/helmDefaults.yaml
+  - base/kubeContext.yaml.gotmpl
 
 defaultInherit:
   # get chart url and version from OCI release


### PR DESCRIPTION
Move `kubeContext` definition into separate `helmDefaults` loadable file.

By having kubeContext definition separately, it allow re-usage in other helmfiles (with different helmDefaults)