### PR TITLE
fix(helmfile): using kubeContext in kubectl hook

### DIFF
--- a/k8s/bootstrap/helmfile/helmfile.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/helmfile.yaml.gotmpl
@@ -17,7 +17,7 @@ releases:
   - name: cilium
     namespace: kube-system
     hooks:
-        # Wait for CRDs to be available
+      # Wait for CRDs to be available
       - command: kubectl
         args:
           - wait
@@ -27,6 +27,8 @@ releases:
           - crd/ciliumbgppeerconfigs.cilium.io
           - crd/ciliumloadbalancerippools.cilium.io
           - --timeout=2m
+          - --context
+          - "{{ printf "admin@%s-homelab" .Environment.Name }}" # non-DRY duplicate kubeContext :-/
         events:
           - postsync
         showlogs: true


### PR DESCRIPTION
Using kubeContext in kubectl command as argument to check for cilium's CRDs being applied in the right cluster

## Motivation

Closes #1056 

## Content

Add a `--context` argument to the `kubectl` hook for the cilium release.

## Caveats

Unfortunately, .Environment.KubeContext could not get used.  Instead, the kubeContext definition had to be repeated/duplicated (non-DRY).

See also implementation options discussion in https://github.com/isejalabs/homelab/issues/1056#issuecomment-5464034523

Also had to transfer the helmfile into a Go template (add filename suffix `.gotmpl`).