### PR TITLE
feat(helmfile): CRD bootstrapping

### DIFF
--- a/k8s/bootstrap/README.md
+++ b/k8s/bootstrap/README.md
@@ -55,13 +55,13 @@ The cluster can be bootstrapped only automatically by leveraging [`helmfile`](ht
 Run the following command to bootstrap the cluster in the `<env>` environment:
 
 ```sh
-helmfile -f k8s/bootstrap/helmfile -e <env> sync --hide-notes
+helmfile -f k8s/bootstrap/helmfile/apps -e <env> sync --hide-notes
 ```
 
 For example, the following command will bootstrap the cluster in the `rebuild` environment:
 
 ```sh
-helmfile -f k8s/bootstrap/helmfile -e rebuild sync --hide-notes
+helmfile -f k8s/bootstrap/helmfile/apps -e rebuild sync --hide-notes
 ```
 
 Output of the command will look like this:

--- a/k8s/bootstrap/README.md
+++ b/k8s/bootstrap/README.md
@@ -3,7 +3,9 @@
 Bootstrapping the cluster is done in 3 stages by different tools:
 
 1. Terragrunt is used to provision the VMs in Proxmox and install Talos OS Kubernetes distribution.
-1. Helmfile is used to install some crucial infrastructure apps in the cluster (cilium CNI, secrets controller, cert-manager, flux).
+1. Helmfile is used to 
+   - install some crucial CRDs in the cluster,
+   - install foundational infrastructure apps in the cluster (e.g. cilium CNI, secrets controller, cert-manager, flux).
 1. Afterwards, Flux CD will automatically reconcile with the Git repository to install all remaining apps in the cluster.
 
 ## Deploying infrastructure and applications
@@ -52,6 +54,36 @@ kubectl get pods -A --field-selector=status.phase!=Running
 
 The cluster can be bootstrapped only automatically by leveraging [`helmfile`](https://helmfile.readthedocs.io/en/latest/) and [Flux CD](https://fluxcd.io/).
 
+### Helmfile
+
+#### Install CRDs in the cluster
+
+Run the following command to install crucial CRDs in the cluster in the `<env>` environment:
+
+```sh
+helmfile -f k8s/bootstrap/helmfile/crds -e <env> template -q | \
+  yq ea -r -e 'select(.kind == "CustomResourceDefinition")' | \
+  kubectl apply --server-side --force-conflicts -f -
+```
+
+For example, the following command will install CRDs in the `rebuild` environment:
+
+```sh
+helmfile -f k8s/bootstrap/helmfile/crds -e rebuild template -q | yq ea -r -e 'select(.kind == "CustomResourceDefinition")' | kubectl apply --server-side --force-conflicts -f -
+```
+
+Output of the command will look like this:
+
+```text
+err: no releases found that matches specified selector() and environment(rebuild), in any helmfile
+Error: no matches found
+error: no objects passed to apply
+```
+
+This is because at the moment no CRDs have been selected for installation.
+
+#### Install apps in the cluster
+
 Run the following command to bootstrap the cluster in the `<env>` environment:
 
 ```sh
@@ -75,4 +107,40 @@ sealed-secrets   sealed-secrets   oci://registry-1.docker.io/bitnamicharts/seale
 cert-manager     cert-manager     oci://quay.io/jetstack/charts/cert-manager                 v1.21.1        29s
 flux-operator    flux-system      oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator   0.58.1         23s
 flux-instance    flux-system      oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance   0.58.1         51s
+```
+
+### Flux CD
+
+You can check the status of cluster bootstrapping by flux by running the `flux` command:
+
+```sh
+flux get ks -A
+```
+
+Output of the command will look like this:
+
+```
+❯ flux get ks -A
+NAMESPACE  	NAME                   	REVISION                     	SUSPENDED	READY	MESSAGE
+flux-system	actualbudget           	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	adguard                	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	cert-manager           	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	checkmk-kube-agent     	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	cilium                 	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	flux-instance          	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	flux-operator          	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	flux-system            	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	gateway-api            	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	gateway-api-crds       	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	gateway-api-redirect   	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	infra-ns               	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	k-serving-cert-approver	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	longhorn               	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	longhorn-core          	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	metrics-server         	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	proxmox-csi            	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	sealed-secrets         	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	unbound                	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	unifi-controller       	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
+flux-system	whoami                 	refs/heads/main@sha1:d50cc11a	False    	True 	Applied revision: refs/heads/main@sha1:d50cc11a
 ```

--- a/k8s/bootstrap/helmfile/apps/helmfile.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/apps/helmfile.yaml.gotmpl
@@ -1,11 +1,18 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/helmfile
 
+# Bootstraps core applications that provide a minimal runtime base for the
+# cluster. These releases are installed first so the cluster has the resources
+# Flux needs before its own reconciliation begins.
+#
+# After this bootstrap phase, Flux is ready to take over management of the
+# application stack and continue reconciling downstream state.
+
 bases:
-  - base/release-templates.yaml
-  - base/environments.yaml
-  - base/helmDefaults.yaml
-  - base/kubeContext.yaml.gotmpl
+  - ../base/environments.yaml
+  - ../base/helmDefaults.yaml
+  - ../base/kubeContext.yaml.gotmpl
+  - ../base/release-templates.yaml
 
 defaultInherit:
   # get chart url and version from OCI release
@@ -33,10 +40,11 @@ releases:
           - postsync
         showlogs: true
     inherit:
-      # do not inherit values from HelmRelease, get them from values.yaml file instead, and we want to avoid conflicts
+      # do not inherit values from HelmRelease...
       - template: values-from-helmrelease
         except:
           - values
+      # get them from values.yaml file instead
       - template: values-from-values-yaml-file
 
   - name: sealed-secrets

--- a/k8s/bootstrap/helmfile/base/release-templates.yaml
+++ b/k8s/bootstrap/helmfile/base/release-templates.yaml
@@ -2,17 +2,17 @@
 # yaml-language-server: $schema=https://json.schemastore.org/helmfile
 templates:
   chart-version-from-ocirelease:
-    chart: '{{ (fromYaml (tpl (readFile "./templates/ocirelease.yaml.gotmpl") .)).chart }}'
-    version: '{{ (fromYaml (tpl (readFile "./templates/ocirelease.yaml.gotmpl") .)).version }}'
+    chart: '{{ (fromYaml (tpl (readFile "../templates/ocirelease.yaml.gotmpl") .)).chart }}'
+    version: '{{ (fromYaml (tpl (readFile "../templates/ocirelease.yaml.gotmpl") .)).version }}'
 
   values-from-values-yaml-file:
     # Ignore missing files, as they are optional and might not exist
     missingFileHandler: Debug
     values:
-      - ../../infra/{{ .Release.Namespace }}/{{ .Release.Name }}/base/values.yaml
-      - ../../infra/{{ .Release.Namespace }}/{{ .Release.Name }}/envs/{{ .Environment.Name }}/values.yaml
+      - ../../../infra/{{ .Release.Namespace }}/{{ .Release.Name }}/base/values.yaml
+      - ../../../infra/{{ .Release.Namespace }}/{{ .Release.Name }}/envs/{{ .Environment.Name }}/values.yaml
 
   values-from-helmrelease:
     values:
-      - ./templates/helmrelease-base-values.yaml.gotmpl
-      - ./templates/helmrelease-env-values.yaml.gotmpl
+      - ../templates/helmrelease-base-values.yaml.gotmpl
+      - ../templates/helmrelease-env-values.yaml.gotmpl

--- a/k8s/bootstrap/helmfile/crds/helmfile.yaml
+++ b/k8s/bootstrap/helmfile/crds/helmfile.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/helmfile
+
+# Bootstraps cluster-wide Custom Resource Definitions (CRDs) by extracting them
+# from upstream Helm charts and applying them directly with kubectl. The releases
+# below are never reconciled with helmfile apply or helmfile sync — only their
+# CRDs are rendered (via --include-crds) and piped to the cluster.
+#
+# Installing CRDs out-of-band ensures they exist before Flux begins reconciling
+# workloads that reference them, avoiding the need for dependsOn chains on nearly
+# every Kustomization that consumes a CRD-backed resource.
+#
+# Usage: helmfile -f k8s/bootstrap/helmfile/crds -e <env> template -q | yq ea -r -e 'select(.kind == "CustomResourceDefinition")' | kubectl apply --server-side --force-conflicts -f -
+
+bases:
+  - ../base/environments.yaml
+  - ../base/kubeContext.yaml.gotmpl
+  - ../base/release-templates.yaml
+
+defaultInherit:
+  # get chart url and version from OCI release
+  - chart-version-from-ocirelease
+  # get chart values from HelmRelease
+  - values-from-helmrelease
+
+helmDefaults:
+  args:
+    - --include-crds
+    - --no-hooks
+
+releases:
+  # PoC testimonial (which is installed already directly)
+  # - name: sealed-secrets
+  #   namespace: sealed-secrets

--- a/k8s/bootstrap/helmfile/templates/helmrelease-base-values.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/templates/helmrelease-base-values.yaml.gotmpl
@@ -7,7 +7,7 @@
   - there's no .spec.values stanza in the helmrelease.yaml file (which might
     occur if the release is not configured with any values).
 */}}
-{{- $baseFile := printf "../../../infra/%s/%s/base/helmrelease.yaml" .Release.Namespace .Release.Name -}}
+{{- $baseFile := printf "../../../../infra/%s/%s/base/helmrelease.yaml" .Release.Namespace .Release.Name -}}
 
 {{- if isFile $baseFile -}}
 {{ dig "spec" "values" (dict) (fromYaml (readFile $baseFile)) | toYaml }}

--- a/k8s/bootstrap/helmfile/templates/helmrelease-env-values.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/templates/helmrelease-env-values.yaml.gotmpl
@@ -8,7 +8,7 @@
     occur if the overlay configures other aspects, e.g. the helm chart version only).
   This template deviates from the base template only for the filename due to the different location
 */}}
-{{- $envFile := printf "../../../infra/%s/%s/envs/%s/helmrelease.yaml" .Release.Namespace .Release.Name .Environment.Name -}}
+{{- $envFile := printf "../../../../infra/%s/%s/envs/%s/helmrelease.yaml" .Release.Namespace .Release.Name .Environment.Name -}}
 
 {{- if isFile $envFile -}}
 {{ dig "spec" "values" (dict) (fromYaml (readFile $envFile)) | toYaml }}

--- a/k8s/bootstrap/helmfile/templates/ocirelease.yaml.gotmpl
+++ b/k8s/bootstrap/helmfile/templates/ocirelease.yaml.gotmpl
@@ -1,6 +1,6 @@
 # 0. Some constants
-{{- $baseFile := printf "../../infra/%s/%s/base/ocirepository.yaml" .Release.Namespace .Release.Name -}}
-{{- $envFile := printf "../../infra/%s/%s/envs/%s/ocirepository.yaml" .Release.Namespace .Release.Name .Environment.Name -}}
+{{- $baseFile := printf "../../../infra/%s/%s/base/ocirepository.yaml" .Release.Namespace .Release.Name -}}
+{{- $envFile := printf "../../../infra/%s/%s/envs/%s/ocirepository.yaml" .Release.Namespace .Release.Name .Environment.Name -}}
 
 # 0. Initialize the environment variable
 {{- $env := dict -}}


### PR DESCRIPTION
Provide possibility for install CRDs (only, i.e. without full application).

## Content

- Establish a 2nd helmfile folder `k8s/bootstrap/helmfile/crds` to cover CRDs installation (none at the moment)
- Move helmfile/helmfile.yaml.gotmpl --> helmfile/apps/helmfile.yaml.gotmpl

Usage:

```sh
helmfile -f k8s/bootstrap/helmfile/crds -e <env> template -q | yq ea -r -e 'select(.kind == "CustomResourceDefinition")' | kubectl apply --server-side --force-conflicts -f -
```

## Motivation

- Closes #979 
- Needed for #1064 
- Maybe also helpful for #1055 